### PR TITLE
add FOV_mask to Dataset

### DIFF
--- a/petric.py
+++ b/petric.py
@@ -205,6 +205,7 @@ class Dataset:
     whole_object_mask: STIR.ImageData | None
     background_mask: STIR.ImageData | None
     voi_masks: dict[str, STIR.ImageData]
+    FOV_mask: STIR.ImageData
     path: PurePath
 
 
@@ -223,6 +224,10 @@ def get_data(srcdir=".", outdir=OUTDIR, sirf_verbosity=0):
     additive_term = STIR.AcquisitionData(str(srcdir / 'additive_term.hs'))
     mult_factors = STIR.AcquisitionData(str(srcdir / 'mult_factors.hs'))
     OSEM_image = STIR.ImageData(str(srcdir / 'OSEM_image.hv'))
+    # Find FOV mask
+    # WARNING: we are currently using Parralelproj with default settings, which uses a cylindrical FOV.
+    # The current code gives identical results to thresholding the sensitivity image (for those settings)
+    FOV_mask = STIR.TruncateToCylinderProcessor().process(OSEM_image.allocate(1))
     kappa = STIR.ImageData(str(srcdir / 'kappa.hv'))
     if (penalty_strength_file := (srcdir / 'penalisation_factor.txt')).is_file():
         penalty_strength = float(np.loadtxt(penalty_strength_file))
@@ -243,7 +248,7 @@ def get_data(srcdir=".", outdir=OUTDIR, sirf_verbosity=0):
         for voi in (srcdir / 'PETRIC').glob("VOI_*.hv") if voi.stem[4:] not in ('background', 'whole_object')}
 
     return Dataset(acquired_data, additive_term, mult_factors, OSEM_image, prior, kappa, reference_image,
-                   whole_object_mask, background_mask, voi_masks, srcdir.resolve())
+                   whole_object_mask, background_mask, voi_masks, FOV_mask, srcdir.resolve())
 
 
 DATA_SLICES = {


### PR DESCRIPTION
`get_data()` now provides an extra member `FOV_mask` that gives the FOV of the projector. This can be used to find which voxels can be non-zero. However, ignoring this mask is safe as VOIs are all well "within" it.

fixes #47, see there for more discussion.

@gschramm, if you need it, you could use this now.