### PR TITLE
evaluation

### DIFF
--- a/SIRF_data_preparation/evaluation_utilities.py
+++ b/SIRF_data_preparation/evaluation_utilities.py
@@ -5,7 +5,6 @@ from typing import Iterable
 
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.ndimage import binary_erosion
 
 import sirf.STIR as STIR
 from petric import QualityMetrics
@@ -23,21 +22,6 @@ def get_metrics(qm: QualityMetrics, iters: Iterable[int], srcdir='.'):
     """Read 'iter_{iter_glob}.hv' images from datadir, compute metrics and return as 2d array"""
     return np.asarray([
         list(qm.evaluate(STIR.ImageData(str(Path(srcdir) / f'iter_{i:04d}.hv'))).values()) for i in iters])
-
-
-def pass_index(metrics: np.ndarray, thresh: Iterable, window: int = 10) -> int:
-    """
-    Returns first index of `metrics` with value <= `thresh`.
-    The values must remain below the respective thresholds for at least `window` number of entries.
-    Otherwise raises IndexError.
-    """
-    thr_arr = np.asanyarray(thresh)
-    assert metrics.ndim == 2
-    assert thr_arr.ndim == 1
-    assert metrics.shape[1] == thr_arr.shape[0]
-    passed = (metrics <= thr_arr[None]).all(axis=1)
-    res = binary_erosion(passed, structure=np.ones(window), origin=-(window // 2))
-    return np.where(res)[0][0]
 
 
 def plot_metrics(iters: Iterable[int], m: np.ndarray, labels=None, suffix=""):

--- a/SIRF_data_preparation/evaluation_utilities.py
+++ b/SIRF_data_preparation/evaluation_utilities.py
@@ -25,7 +25,7 @@ def get_metrics(qm: QualityMetrics, iters: Iterable[int], srcdir='.'):
         list(qm.evaluate(STIR.ImageData(str(Path(srcdir) / f'iter_{i:04d}.hv'))).values()) for i in iters])
 
 
-def pass_index(metrics: np.ndarray, thresh: Iterable, window: int = 1) -> int:
+def pass_index(metrics: np.ndarray, thresh: Iterable, window: int = 10) -> int:
     """
     Returns first index of `metrics` with value <= `thresh`.
     The values must remain below the respective thresholds for at least `window` number of entries.

--- a/SIRF_data_preparation/plot_BSREM_metrics.py
+++ b/SIRF_data_preparation/plot_BSREM_metrics.py
@@ -11,7 +11,7 @@ import sirf.STIR as STIR
 from petric import OUTDIR, SRCDIR, QualityMetrics, get_data
 from SIRF_data_preparation import data_QC
 from SIRF_data_preparation.dataset_settings import get_settings
-from SIRF_data_preparation.evaluation_utilities import get_metrics, pass_index, plot_metrics, read_objectives
+from SIRF_data_preparation.evaluation_utilities import get_metrics, plot_metrics, read_objectives
 
 if not all((SRCDIR.is_dir(), OUTDIR.is_dir())):
     PETRICDIR = Path('~/devel/PETRIC').expanduser()
@@ -112,7 +112,7 @@ if m1 is not None:
     fig.savefig(outdir / f'{scanID}_metrics_BSREM.png')
 
 # %%
-idx = pass_index(m, numpy.array([.01, .01] + [.005 for i in range(len(data.voi_masks))]), 10)
+idx = QualityMetrics.pass_index(m, numpy.array([.01, .01] + [.005 for i in range(len(data.voi_masks))]), 10)
 iter = iters[idx]
 print(iter)
 image = STIR.ImageData(str(datadir / f"iter_{iter:04d}.hv"))

--- a/petric.py
+++ b/petric.py
@@ -147,7 +147,7 @@ class QualityMetrics(ImageQualityCallback, Callback):
 
 class MetricsWithTimeout(cil_callbacks.Callback):
     """Stops the algorithm after `seconds`"""
-    def __init__(self, seconds=600, outdir=OUTDIR, transverse_slice=None, coronal_slice=None, sagittal_slice=None,
+    def __init__(self, seconds=3600, outdir=OUTDIR, transverse_slice=None, coronal_slice=None, sagittal_slice=None,
                  **kwargs):
         super().__init__(**kwargs)
         self._seconds = seconds

--- a/petric.py
+++ b/petric.py
@@ -94,11 +94,12 @@ class StatsLog(Callback):
         self.sagittal_slice = algo.x.dimensions()[2] // 2 if self.sagittal_slice is None else self.sagittal_slice
         self.vmax = algo.x.max() if self.vmax is None else self.vmax
 
-        self.tb.add_scalar("objective", algo.get_last_loss(), algo.iteration, t)
-        if self.x_prev is not None:
-            normalised_change = (algo.x - self.x_prev).norm() / algo.x.norm()
-            self.tb.add_scalar("normalised_change", normalised_change, algo.iteration, t)
-        self.x_prev = algo.x.clone()
+        if log.getEffectiveLevel() <= logging.DEBUG:
+            self.tb.add_scalar("objective", algo.get_last_loss(), algo.iteration, t)
+            if self.x_prev is not None:
+                normalised_change = (algo.x - self.x_prev).norm() / algo.x.norm()
+                self.tb.add_scalar("normalised_change", normalised_change, algo.iteration, t)
+            self.x_prev = algo.x.clone()
         x_arr = algo.x.as_array()
         self.tb.add_image("transverse", np.clip(x_arr[None, self.transverse_slice] / self.vmax, 0, 1), algo.iteration,
                           t)

--- a/petric.py
+++ b/petric.py
@@ -43,7 +43,7 @@ class Callback(cil_callbacks.Callback):
     CIL Callback but with `self.skip_iteration` checking `min(self.interval, algo.update_objective_interval)`.
     TODO: backport this class to CIL.
     """
-    def __init__(self, interval: int = 3, **kwargs):
+    def __init__(self, interval: int = 1, **kwargs):
         super().__init__(**kwargs)
         self.interval = interval
 
@@ -110,7 +110,7 @@ class StatsLog(Callback):
 
 class QualityMetrics(ImageQualityCallback, Callback):
     """From https://github.com/SyneRBI/PETRIC/wiki#metrics-and-thresholds"""
-    def __init__(self, reference_image, whole_object_mask, background_mask, interval: int = 3, **kwargs):
+    def __init__(self, reference_image, whole_object_mask, background_mask, interval: int = 1, **kwargs):
         # TODO: drop multiple inheritance once `interval` included in CIL
         Callback.__init__(self, interval=interval)
         ImageQualityCallback.__init__(self, reference_image, **kwargs)

--- a/petric.py
+++ b/petric.py
@@ -292,8 +292,11 @@ else:
     from traceback import print_exc
 
     from docopt import docopt
+    from tqdm.contrib.logging import logging_redirect_tqdm
     args = docopt(__doc__)
     logging.basicConfig(level=getattr(logging, args["--log"].upper()))
+    redir = logging_redirect_tqdm()
+    redir.__enter__()
     from main import Submission, submission_callbacks
     assert issubclass(Submission, Algorithm)
     for srcdir, outdir, metrics in data_dirs_metrics:


### PR DESCRIPTION
- metrics
  - [x] fix wall-time override (fixes #67)
  - [x] compute per-iteration (follow-up to #91)
  - [x] skip `objective` (fixes #91 <- fixes #82)
  - [x] skip `normalised_change`
  - [x] add relative timing helper (`"reset"` scalar)
- `raise StopIteration`
  - [x] increase timeout from 10 min to 1 hour
  - [x] also stop if thresholds reached for `>= 10` iteration window
- better `logging` ↔️ `tqdm` interaction
- move `pass_index` to `petric` for ease of use